### PR TITLE
kubetest params added to install stable k8s cluster

### DIFF
--- a/cluster-setup.sh
+++ b/cluster-setup.sh
@@ -14,7 +14,9 @@ then
       --powervs-service-id af3e8574-29ea-41a2-a9c5-e88cba5c5858 \
       --powervs-ssh-key knative-ssh-key \
       --ssh-private-key ~/.ssh/ssh-key \
+      --directory release \
       --build-version $K8S_BUILD_VERSION \
+      --release-marker release/$K8S_BUILD_VERSION \
       --cluster-name knative-$TIMESTAMP \
       --workers-count 2 \
       --playbook install-k8s-kn-tkn.yml \


### PR DESCRIPTION
## Enhancing Kubetest for Stable Kubernetes Cluster Installation
This update introduces modifications to **Kubetest** to ensure the installation of a stable Kubernetes cluster. 

## Changes Introduced
The following parameters have been added to **Kubetest**:

- `--directory release`  
  - Specifies the release directory to fetch the stable Kubernetes artifacts.
- `--release-marker release/$K8S_BUILD_VERSION`  
  - Ensures that Kubetest installs the correct Kubernetes build version from stable releases instead of the latest development builds.

## Why This Change?
Previously, Kubetest defaulted to pulling the latest Kubernetes builds, which could introduce unexpected compatibility issues. The latest development builds may include breaking changes or untested features that affect cluster stability

